### PR TITLE
Fix typo "Aproximately" to "Approximately"

### DIFF
--- a/src/components/Faq.vue
+++ b/src/components/Faq.vue
@@ -18,7 +18,7 @@
       <template v-else-if="diff.totalDays === 1">day.</template>
       <template v-else>days.</template>
       <template v-if="diff.totalDays > 100">
-        Aproximately
+        Approximately
         <template v-if="diff.years > 0">
           {{ diff.years }}
           <template v-if="diff.years > 1">years</template>


### PR DESCRIPTION
Not much else to add here. A simple typo fix.